### PR TITLE
Update sipInfoReceived content accessed map key

### DIFF
--- a/lib/src/call/call.dart
+++ b/lib/src/call/call.dart
@@ -563,7 +563,7 @@ class VICall {
         break;
       case 'sipInfoReceived':
         String type = map['type'];
-        String content = map['content'];
+        String content = map['body'];
         Map<String, String> headers = new Map();
         map['headers'].forEach(
             (key, value) => {headers[key as String] = value as String});


### PR DESCRIPTION
fixes #20 

As mentioned in issue, this is the log before fixing
![image](https://user-images.githubusercontent.com/78375092/112373038-4a697700-8cbf-11eb-9282-91c1f0a3d99c.png)

And this is after fixing
![Screen Shot 2021-03-24 at 16 36 54](https://user-images.githubusercontent.com/78375092/112373073-50f7ee80-8cbf-11eb-9bfd-cb4f1ddd58f5.png)

Notice that native log is fine, but content was null on flutter plugin.