### PR TITLE
VIQualityIssue mapping fix

### DIFF
--- a/lib/src/call/quality_issue.dart
+++ b/lib/src/call/quality_issue.dart
@@ -101,7 +101,7 @@ abstract class VIQualityIssue {
   final VIQualityIssueLevel level;
 
   VIQualityIssue._fromMap(Map<dynamic, dynamic> map)
-      : this.level = map['level'];
+      : this.level = VIQualityIssueLevel.values[map['issueLevel']];
 }
 
 /// Represents a quality issue reporting that the local video is encoded by a


### PR DESCRIPTION
```
[VERBOSE-2:ui_dart_state.cc(198)] Unhandled Exception: type 'Null' is not a subtype of type 'VIQualityIssueLevel'
#0      new VIQualityIssue._fromMap (package:flutter_voximplant/src/call/quality_issue.dart:104:20)
#1      new VIPacketLoss._fromMap (package:flutter_voximplant/src/call/quality_issue.dart:237:15)
#2      _VICallQualityIssue._listener (package:flutter_voximplant/src/call/quality_issue.dart:350:51)
#3      _rootRunUnary (dart:async/zone.dart:1434:47)
#4      _CustomZone.runUnary (dart:async/zone.dart:1335:19)
#5      _CustomZone.runUnaryGuarded (dart:async/zone.dart:1244:7)
#6      _BufferingStreamSubscription._sendData (dart:async/stream_impl.dart:341:11)
#7      _DelayedData.perform (dart:async/stream_impl.dart:591:14)
```